### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: "CodeQL"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Seems868/Public_repo1/security/code-scanning/1](https://github.com/Seems868/Public_repo1/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key to restrict the `GITHUB_TOKEN` to the minimum required privileges. For a CodeQL analysis workflow, this is typically `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). The best practice is to set it at the workflow level unless a specific job requires different permissions. The change should be made at the top level of `.github/workflows/main.yml`, immediately after the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
